### PR TITLE
Throw Facturapi_Exception on http response code error

### DIFF
--- a/src/Http/BaseClient.php
+++ b/src/Http/BaseClient.php
@@ -196,11 +196,17 @@ class BaseClient {
 		$output = curl_exec( $ch );
 		$errno  = curl_errno( $ch );
 		$error  = curl_error( $ch );
+		//Get response code, only numbers in range from 200 to 299 are valid
+		$responseCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 		$this->setLastStatusFromCurl( $ch );
 		curl_close( $ch );
 		if ( $errno > 0 ) {
 			throw new Facturapi_Exception( 'cURL error: ' . $error );
-		} else {
+		} elseif ($responseCode < 200 || $responseCode > 299) {
+		    //Decode response body to get error message from API
+	            $outputDecoded = json_decode($output, true);
+	            throw new Facturapi_Exception($outputDecoded['message']);
+        	}else {
 			return $output;
 		}
 	}


### PR DESCRIPTION
If http response code is not in the range from 200 to 299 will throw a Facturapi_Exception with the error code from FacturaAPI message.

En estos momentos si FacturaAPI te regresa un error, no hace throw una Exception, y te das cuenta ya que te regreso el json teniendo que verificar si el "ok" es true o false, como esto agrega mas codigo y una verificacion extra, es mas facil que desde el request se verifique si el http response code esta fuera del rango de 200 a 299, que en teoria son rangos donde todo estubo ok.