### PR TITLE
fix: Se modifican los mensajes retornados en las excepciones

### DIFF
--- a/src/Resources/Catalogs.php
+++ b/src/Resources/Catalogs.php
@@ -25,7 +25,7 @@ class Catalogs extends BaseClient {
         )
       );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to search products: ' . $e );
+			throw new Facturapi_Exception( 'Unable to search products: ' . $e->getMessage() );
 		}
 	}
 
@@ -46,7 +46,7 @@ class Catalogs extends BaseClient {
         )
       );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to search unit keys: ' . $e );
+			throw new Facturapi_Exception( 'Unable to search unit keys: ' . $e->getMessage() );
 		}
 	}
 

--- a/src/Resources/Customers.php
+++ b/src/Resources/Customers.php
@@ -21,7 +21,7 @@ class Customers extends BaseClient {
 		try {
 			return json_decode( $this->execute_get_request( $this->get_request_url( $params ) ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to get customers: ' . $e );
+			throw new Facturapi_Exception( 'Unable to get customers: ' . $e->getMessage() );
 		}
 	}
 
@@ -38,7 +38,7 @@ class Customers extends BaseClient {
 		try {
 			return json_decode( $this->execute_get_request( $this->get_request_url( $id ) ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to get customer: ' . $e );
+			throw new Facturapi_Exception( 'Unable to get customer: ' . $e->getMessage() );
 		}
 	}
 
@@ -56,7 +56,7 @@ class Customers extends BaseClient {
 		try {
 			return json_decode( $this->execute_JSON_post_request( $this->get_request_url(), $params ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to create customer: ' . $e );
+			throw new Facturapi_Exception( 'Unable to create customer: ' . $e->getMessage() );
 		}
 	}
 
@@ -76,7 +76,7 @@ class Customers extends BaseClient {
 		try {
 			return json_decode( $this->execute_JSON_put_request( $this->get_request_url( $id ), $params ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to update customer: ' . $e );
+			throw new Facturapi_Exception( 'Unable to update customer: ' . $e->getMessage() );
 		}
 	}
 
@@ -93,7 +93,7 @@ class Customers extends BaseClient {
 		try {
 			return json_decode( $this->execute_delete_request( $this->get_request_url( $id ), null ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to delete customer: ' . $e );
+			throw new Facturapi_Exception( 'Unable to delete customer: ' . $e->getMessage() );
 		}
 	}
 	
@@ -110,7 +110,7 @@ class Customers extends BaseClient {
 		try {
 			return json_decode( $this->execute_get_request( $this->get_request_url( $id ) . "/tax-info-validation" ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to validate customer\'s tax info: ' . $e );
+			throw new Facturapi_Exception( 'Unable to validate customer\'s tax info: ' . $e->getMessage() );
 		}
 	}
 

--- a/src/Resources/Invoices.php
+++ b/src/Resources/Invoices.php
@@ -22,7 +22,7 @@ class Invoices extends BaseClient {
 		try {
 			return json_decode( $this->execute_get_request( $this->get_request_url( $params ) ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to get Invoices: ' . $e );
+			throw new Facturapi_Exception( 'Unable to get Invoices: ' . $e->getMessage() );
 		}
 	}
 
@@ -39,7 +39,7 @@ class Invoices extends BaseClient {
 		try {
 			return json_decode( $this->execute_get_request( $this->get_request_url( $id ) ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to get Invoice: ' . $e );
+			throw new Facturapi_Exception( 'Unable to get Invoice: ' . $e->getMessage());
 		}
 	}
 
@@ -57,7 +57,7 @@ class Invoices extends BaseClient {
 		try {
 			return json_decode( $this->execute_JSON_post_request( $this->get_request_url($query), $params) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to create Invoice: ' . $e );
+			throw new Facturapi_Exception( 'Unable to create Invoice: ' . $e->getMessage());
 		}
 	}
 
@@ -77,7 +77,7 @@ class Invoices extends BaseClient {
 		try {
 			return json_decode( $this->execute_delete_request( $this->get_request_url( $id, $params ), null ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to cancel Invoice: ' . $e );
+			throw new Facturapi_Exception( 'Unable to cancel Invoice: ' . $e->getMessage());
 		}
 	}
 
@@ -97,7 +97,7 @@ class Invoices extends BaseClient {
 				array("email" => $email)
 			));
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to send Invoice: ' . $e );
+			throw new Facturapi_Exception( 'Unable to send Invoice: ' . $e->getMessage());
 		}
 	}
 
@@ -114,7 +114,7 @@ class Invoices extends BaseClient {
 		try {
 			return $this->execute_get_request( $this->get_request_url( $id ) . "/zip" );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to download ZIP file: ' . $e );
+			throw new Facturapi_Exception( 'Unable to download ZIP file: ' . $e->getMessage());
 		}
 	}
 
@@ -131,7 +131,7 @@ class Invoices extends BaseClient {
 		try {
 			return $this->execute_get_request( $this->get_request_url( $id ) . "/pdf" );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to download PDF file: ' . $e );
+			throw new Facturapi_Exception( 'Unable to download PDF file: ' . $e->getMessage());
 		}
 	}
 
@@ -148,7 +148,7 @@ class Invoices extends BaseClient {
 		try {
 			return $this->execute_get_request( $this->get_request_url( $id ) . "/xml" );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to download XML file: ' . $e );
+			throw new Facturapi_Exception( 'Unable to download XML file: ' . $e->getMessage());
 		}
 	}
 
@@ -165,7 +165,7 @@ class Invoices extends BaseClient {
 		try {
 			return $this->execute_get_request( $this->get_request_url( $id ) . "/cancellation_receipt/xml" );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to download cancellation receipt: ' . $e );
+			throw new Facturapi_Exception( 'Unable to download cancellation receipt: ' . $e->getMessage());
 		}
 	}
 
@@ -182,7 +182,7 @@ class Invoices extends BaseClient {
 		try {
 			return $this->execute_get_request( $this->get_request_url( $id ) . "/cancellation_receipt/pdf" );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to download cancellation receipt: ' . $e );
+			throw new Facturapi_Exception( 'Unable to download cancellation receipt: ' . $e->getMessage());
 		}
 	}
 }

--- a/src/Resources/Organizations.php
+++ b/src/Resources/Organizations.php
@@ -24,7 +24,7 @@ class Organizations extends BaseClient
     try {
       return json_decode($this->execute_get_request($this->get_request_url($params)));
     } catch (Facturapi_Exception $e) {
-      throw new Facturapi_Exception('Unable to get organizations: ' . $e);
+      throw new Facturapi_Exception('Unable to get organizations: ' . $e->getMessage());
     }
   }
 
@@ -42,7 +42,7 @@ class Organizations extends BaseClient
     try {
       return json_decode($this->execute_get_request($this->get_request_url($id)));
     } catch (Facturapi_Exception $e) {
-      throw new Facturapi_Exception('Unable to get organization: ' . $e);
+      throw new Facturapi_Exception('Unable to get organization: ' . $e->getMessage());
     }
   }
 
@@ -61,7 +61,7 @@ class Organizations extends BaseClient
     try {
       return json_decode($this->execute_JSON_post_request($this->get_request_url(), $params));
     } catch (Facturapi_Exception $e) {
-      throw new Facturapi_Exception('Unable to create organization: ' . $e);
+      throw new Facturapi_Exception('Unable to create organization: ' . $e->getMessage());
     }
   }
 
@@ -81,7 +81,7 @@ class Organizations extends BaseClient
     try {
       return json_decode($this->execute_JSON_put_request($this->get_request_url($id) . "/legal", $params));
     } catch (Facturapi_Exception $e) {
-      throw new Facturapi_Exception('Unable to update organization\'s legal information: ' . $e);
+      throw new Facturapi_Exception('Unable to update organization\'s legal information: ' . $e->getMessage());
     }
   }
 
@@ -101,7 +101,7 @@ class Organizations extends BaseClient
     try {
       return json_decode($this->execute_JSON_put_request($this->get_request_url($id) . "/customization", $params));
     } catch (Facturapi_Exception $e) {
-      throw new Facturapi_Exception('Unable to update organization\'s customization information: ' . $e);
+      throw new Facturapi_Exception('Unable to update organization\'s customization information: ' . $e->getMessage());
     }
   }
 
@@ -121,7 +121,7 @@ class Organizations extends BaseClient
     try {
       return json_decode($this->execute_JSON_put_request($this->get_request_url($id) . "/receipts", $params));
     } catch (Facturapi_Exception $e) {
-      throw new Facturapi_Exception('Unable to update organization\'s receipt settings: ' . $e);
+      throw new Facturapi_Exception('Unable to update organization\'s receipt settings: ' . $e->getMessage());
     }
   }
 
@@ -141,7 +141,7 @@ class Organizations extends BaseClient
     try {
       return json_decode($this->execute_JSON_put_request($this->get_request_url($id) . "/domain", $params));
     } catch (Facturapi_Exception $e) {
-      throw new Facturapi_Exception('Unable to update organization\'s domain: ' . $e);
+      throw new Facturapi_Exception('Unable to update organization\'s domain: ' . $e->getMessage());
     }
   }
 
@@ -165,7 +165,7 @@ class Organizations extends BaseClient
         )
       );
     } catch (Facturapi_Exception $e) {
-      throw new Facturapi_Exception('Unable to check domain\'s availability: ' . $e);
+      throw new Facturapi_Exception('Unable to check domain\'s availability: ' . $e->getMessage());
     }
   }
 
@@ -185,7 +185,7 @@ class Organizations extends BaseClient
     try {
       return json_decode($this->execute_data_put_request($this->get_request_url($id) . "/logo", $params));
     } catch (Facturapi_Exception $e) {
-      throw new Facturapi_Exception('Unable to upload organization\'s logo: ' . $e);
+      throw new Facturapi_Exception('Unable to upload organization\'s logo: ' . $e->getMessage());
     }
   }
 
@@ -205,7 +205,7 @@ class Organizations extends BaseClient
     try {
       return json_decode($this->execute_data_put_request($this->get_request_url($id) . "/certificate", $params));
     } catch (Facturapi_Exception $e) {
-      throw new Facturapi_Exception('Unable to upload organization\'s certificate (CSD): ' . $e);
+      throw new Facturapi_Exception('Unable to upload organization\'s certificate (CSD): ' . $e->getMessage());
     }
   }
 
@@ -223,7 +223,7 @@ class Organizations extends BaseClient
     try {
       return json_decode($this->execute_get_request($this->get_request_url($id) . "/apikeys/test"));
     } catch (Facturapi_Exception $e) {
-      throw new Facturapi_Exception('Unable to get organization\'s test key: ' . $e);
+      throw new Facturapi_Exception('Unable to get organization\'s test key: ' . $e->getMessage());
     }
   }
   
@@ -246,7 +246,7 @@ class Organizations extends BaseClient
         )
       );
     } catch (Facturapi_Exception $e) {
-      throw new Facturapi_Exception('Unable to renew organization\'s test key: ' . $e);
+      throw new Facturapi_Exception('Unable to renew organization\'s test key: ' . $e->getMessage());
     }
   }
   
@@ -269,7 +269,7 @@ class Organizations extends BaseClient
         )
       );
     } catch (Facturapi_Exception $e) {
-      throw new Facturapi_Exception('Unable to renew organization\'s live key: ' . $e);
+      throw new Facturapi_Exception('Unable to renew organization\'s live key: ' . $e->getMessage());
     }
   }
 
@@ -287,7 +287,7 @@ class Organizations extends BaseClient
     try {
       return json_decode($this->execute_delete_request($this->get_request_url($id), null));
     } catch (Facturapi_Exception $e) {
-      throw new Facturapi_Exception('Unable to delete organization: ' . $e);
+      throw new Facturapi_Exception('Unable to delete organization: ' . $e->getMessage());
     }
   }
 
@@ -305,7 +305,7 @@ class Organizations extends BaseClient
     try {
       return json_decode($this->execute_delete_request($this->get_request_url($id) .  "/certificate", null));
     } catch (Facturapi_Exception $e) {
-      throw new Facturapi_Exception('Unable to delete organization: ' . $e);
+      throw new Facturapi_Exception('Unable to delete organization: ' . $e->getMessage());
     }
   }
 }

--- a/src/Resources/Products.php
+++ b/src/Resources/Products.php
@@ -22,7 +22,7 @@ class Products extends BaseClient {
 		try {
 			return json_decode( $this->execute_get_request( $this->get_request_url( $params ) ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to get products: ' . $e );
+			throw new Facturapi_Exception( 'Unable to get products: ' . $e->getMessage() );
 		}
 	}
 
@@ -39,7 +39,7 @@ class Products extends BaseClient {
 		try {
 			return json_decode( $this->execute_get_request( $this->get_request_url( $id ) ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to get product: ' . $e );
+			throw new Facturapi_Exception( 'Unable to get product: ' . $e->getMessage() );
 		}
 	}
 
@@ -57,7 +57,7 @@ class Products extends BaseClient {
 		try {
 			return json_decode( $this->execute_JSON_post_request( $this->get_request_url(), $params ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to create product: ' . $e );
+			throw new Facturapi_Exception( 'Unable to create product: ' . $e->getMessage() );
 		}
 	}
 
@@ -77,7 +77,7 @@ class Products extends BaseClient {
 		try {
 			return json_decode( $this->execute_JSON_put_request( $this->get_request_url( $id ), $params ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to update product: ' . $e );
+			throw new Facturapi_Exception( 'Unable to update product: ' . $e->getMessage() );
 		}
 	}
 
@@ -94,7 +94,7 @@ class Products extends BaseClient {
 		try {
 			return json_decode( $this->execute_delete_request( $this->get_request_url( $id ), null ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to delete product: ' . $e );
+			throw new Facturapi_Exception( 'Unable to delete product: ' . $e->getMessage() );
 		}
 	}
 

--- a/src/Resources/Receipts.php
+++ b/src/Resources/Receipts.php
@@ -22,7 +22,7 @@ class Receipts extends BaseClient {
 		try {
 			return json_decode( $this->execute_get_request( $this->get_request_url( $params ) ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to get receipts: ' . $e );
+			throw new Facturapi_Exception( 'Unable to get receipts: ' . $e->getMessage() );
 		}
 	}
 
@@ -39,7 +39,7 @@ class Receipts extends BaseClient {
 		try {
 			return json_decode( $this->execute_get_request( $this->get_request_url( $id ) ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to get receipt: ' . $e );
+			throw new Facturapi_Exception( 'Unable to get receipt: ' . $e->getMessage() );
 		}
 	}
 
@@ -56,7 +56,7 @@ class Receipts extends BaseClient {
 		try {
 			return json_decode( $this->execute_JSON_post_request( $this->get_request_url(), $params ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to create receipt: ' . $e );
+			throw new Facturapi_Exception( 'Unable to create receipt: ' . $e->getMessage() );
 		}
 	}
 
@@ -76,7 +76,7 @@ class Receipts extends BaseClient {
 		try {
 			return json_decode( $this->execute_JSON_post_request( $this->get_request_url( $id ) . "/invoice", $params ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to invoice receipt: ' . $e );
+			throw new Facturapi_Exception( 'Unable to invoice receipt: ' . $e->getMessage() );
 		}
 	}
 	
@@ -94,7 +94,7 @@ class Receipts extends BaseClient {
 		try {
 			return json_decode( $this->execute_JSON_post_request( $this->get_request_url() . "/global-invoice", $params ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to create global invoice: ' . $e );
+			throw new Facturapi_Exception( 'Unable to create global invoice: ' . $e->getMessage() );
 		}
 	}
 
@@ -111,7 +111,7 @@ class Receipts extends BaseClient {
 		try {
 			return json_decode( $this->execute_delete_request( $this->get_request_url( $id ), null ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to cancel receipt: ' . $e );
+			throw new Facturapi_Exception( 'Unable to cancel receipt: ' . $e->getMessage() );
 		}
 	}
 
@@ -131,7 +131,7 @@ class Receipts extends BaseClient {
 				$email == null ? null : array("email" => $email)
 			));
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to send Receipt: ' . $e );
+			throw new Facturapi_Exception( 'Unable to send Receipt: ' . $e->getMessage() );
 		}
 	}
 
@@ -148,7 +148,7 @@ class Receipts extends BaseClient {
 		try {
 			return $this->execute_get_request( $this->get_request_url( $id ) . "/pdf" );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to download PDF file: ' . $e );
+			throw new Facturapi_Exception( 'Unable to download PDF file: ' . $e->getMessage() );
 		}
 	}
 }

--- a/src/Resources/Retentions.php
+++ b/src/Resources/Retentions.php
@@ -22,7 +22,7 @@ class Retentions extends BaseClient {
 		try {
 			return json_decode( $this->execute_get_request( $this->get_request_url( $params ) ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to get Retentions: ' . $e );
+			throw new Facturapi_Exception( 'Unable to get Retentions: ' . $e->getMessage() );
 		}
 	}
 
@@ -39,7 +39,7 @@ class Retentions extends BaseClient {
 		try {
 			return json_decode( $this->execute_get_request( $this->get_request_url( $id ) ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to get Retention: ' . $e );
+			throw new Facturapi_Exception( 'Unable to get Retention: ' . $e->getMessage() );
 		}
 	}
 
@@ -56,7 +56,7 @@ class Retentions extends BaseClient {
 		try {
 			return json_decode( $this->execute_JSON_post_request( $this->get_request_url(), $params ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to create Retention: ' . $e );
+			throw new Facturapi_Exception( 'Unable to create Retention: ' . $e->getMessage() );
 		}
 	}
 
@@ -74,7 +74,7 @@ class Retentions extends BaseClient {
 		try {
 			return json_decode( $this->execute_delete_request( $this->get_request_url( $id ), null ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to cancel Retention: ' . $e );
+			throw new Facturapi_Exception( 'Unable to cancel Retention: ' . $e->getMessage() );
 		}
 	}
 
@@ -96,7 +96,7 @@ class Retentions extends BaseClient {
 				array("email" => $email)
 			));
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to send Retention: ' . $e );
+			throw new Facturapi_Exception( 'Unable to send Retention: ' . $e->getMessage() );
 		}
 	}
 
@@ -113,7 +113,7 @@ class Retentions extends BaseClient {
 		try {
 			return $this->execute_get_request( $this->get_request_url( $id ) . "/zip" );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to download ZIP file: ' . $e );
+			throw new Facturapi_Exception( 'Unable to download ZIP file: ' . $e->getMessage() );
 		}
 	}
 
@@ -130,7 +130,7 @@ class Retentions extends BaseClient {
 		try {
 			return $this->execute_get_request( $this->get_request_url( $id ) . "/pdf" );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to download PDF file: ' . $e );
+			throw new Facturapi_Exception( 'Unable to download PDF file: ' . $e->getMessage() );
 		}
 	}
 
@@ -147,7 +147,7 @@ class Retentions extends BaseClient {
 		try {
 			return $this->execute_get_request( $this->get_request_url( $id ) . "/xml" );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to download XML file: ' . $e );
+			throw new Facturapi_Exception( 'Unable to download XML file: ' . $e->getMessage() );
 		}
 	}
 }

--- a/src/Resources/Tools.php
+++ b/src/Resources/Tools.php
@@ -30,7 +30,7 @@ class Tools extends BaseClient {
         )
       );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Failed to validate tax id: ' . $e );
+			throw new Facturapi_Exception( 'Failed to validate tax id: ' .$e->getMessage() );
 		}
 	}
 

--- a/src/Resources/Webhooks.php
+++ b/src/Resources/Webhooks.php
@@ -21,7 +21,7 @@ class Webhooks extends BaseClient {
 		try {
 			return json_decode( $this->execute_get_request( $this->get_request_url( $params ) ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to get webhooks: ' . $e );
+			throw new Facturapi_Exception( 'Unable to get webhooks: ' . $e->getMessage() );
 		}
 	}
 
@@ -38,7 +38,7 @@ class Webhooks extends BaseClient {
 		try {
 			return json_decode( $this->execute_get_request( $this->get_request_url( $id ) ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to get webhook: ' . $e );
+			throw new Facturapi_Exception( 'Unable to get webhook: ' . $e->getMessage() );
 		}
 	}
 
@@ -56,7 +56,7 @@ class Webhooks extends BaseClient {
 		try {
 			return json_decode( $this->execute_JSON_post_request( $this->get_request_url(), $params ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to create webhook: ' . $e );
+			throw new Facturapi_Exception( 'Unable to create webhook: ' . $e->getMessage() );
 		}
 	}
 
@@ -76,7 +76,7 @@ class Webhooks extends BaseClient {
 		try {
 			return json_decode( $this->execute_JSON_put_request( $this->get_request_url( $id ), $params ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to update webhook: ' . $e );
+			throw new Facturapi_Exception( 'Unable to update webhook: ' . $e->getMessage() );
 		}
 	}
 
@@ -93,7 +93,7 @@ class Webhooks extends BaseClient {
 		try {
 			return json_decode( $this->execute_delete_request( $this->get_request_url( $id ), null ) );
 		} catch ( Facturapi_Exception $e ) {
-			throw new Facturapi_Exception( 'Unable to delete webhook: ' . $e );
+			throw new Facturapi_Exception( 'Unable to delete webhook: ' . $e->getMessage() );
 		}
 	}
 


### PR DESCRIPTION
Se estaba retornando los trace completos en el mensaje cuando se tiraba una excepción, pero únicamente ocurría dentro de los resources ya que retornaba $e pero debía de retornar $e->getMessage()