### PR TITLE
Return error instead of throwing exception

### DIFF
--- a/src/Http/BaseClient.php
+++ b/src/Http/BaseClient.php
@@ -202,10 +202,6 @@ class BaseClient {
 		curl_close( $ch );
 		if ( $errno > 0 ) {
 			throw new Facturapi_Exception( 'cURL error: ' . $error );
-		} elseif ($responseCode < 200 || $responseCode > 299) {
-		    //Decode response body to get error message from API
-	            $outputDecoded = json_decode($output, true);
-	            throw new Facturapi_Exception($outputDecoded['message']);
         	}else {
 			return $output;
 		}

--- a/src/Http/BaseClient.php
+++ b/src/Http/BaseClient.php
@@ -202,7 +202,7 @@ class BaseClient {
 		curl_close( $ch );
 		if ( $errno > 0 ) {
 			throw new Facturapi_Exception( 'cURL error: ' . $error );
-        	}else {
+		} else {
 			return $output;
 		}
 	}


### PR DESCRIPTION
Revirtiendo este PR https://github.com/FacturAPI/facturapi-php/pull/18

De la forma que esta implementado este error ahora no tienes acceso al mensaje de error ya que se incluye todo el stacktrace. 

Ademas deja de seguir la convencion de los otros metodos de la clase que regresan el output aun cuando ocurre un error.

En el PR se menciona que se tiene que revisar si respondio ok y que agrega mas codigo, pero creo me parece que es la mejor opcion para poder obtener la informacion de la respuesta.