### PR TITLE
Add organization team management methods to PHP SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ composer.phar
 composer.lock
 /.idea/
 .DS_Store
+.phpunit.cache/

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,31 +1,9 @@
-4.0.0
+4.1.0
 
-## 🚨 Breaking Changes
-- Impact: update required only if you use PHP < 8.2 or relied on the positional `apiVersion` constructor argument.
-- Bumped minimum supported PHP version to `>=8.2`.
-- Simplified SDK constructor to a single optional `config` parameter:
-  - `apiVersion` (defaults to `v2`)
-  - `timeout` (seconds)
-  - `httpClient` (PSR-18 client, advanced)
-- Removed support for the positional `apiVersion` constructor argument.
-
-## Safe Update (No Migration Needed)
-- You can update without code changes if:
-  - Your project already runs on PHP `>=8.2`.
-  - You instantiate the SDK as `new Facturapi($apiKey)` (single API key argument).
-  - If you use Composer, keep loading `vendor/autoload.php` as usual.
-  - If you do not use Composer, load `src/Facturapi.php` directly.
-
-## Deprecations (Non-Breaking)
-- Snake_case aliases remain functional in v4, but are deprecated and will be removed in v5.
-- `Facturapi_Exception` remains functional in v4 through a compatibility alias, but is deprecated and will be removed in v5.
-
-## Improvements
-- Added camelCase method names for invoice/receipt/retention actions.
-- Kept snake_case aliases for transition compatibility.
-- Enabled strict TLS verification by default for HTTP requests.
-- `Webhooks::validateSignature()` now verifies locally by default when payload includes `body`/`payload`, `signature`, and `webhookSecret`, with automatic fallback to API validation.
-- Added `ComercioExteriorCatalogs` to the main `Facturapi` client.
-- Standardized constructor argument names to camelCase.
-- Standardized internal protected method names to camelCase.
-- Renamed exception class to `FacturapiException` and kept `Facturapi_Exception` as a compatibility alias.
+## Added
+- Organization team/access management methods:
+  - `listTeamAccess`, `retrieveTeamAccess`, `removeTeamAccess`
+  - `listSentTeamInvites`, `inviteUserToTeam`, `cancelTeamInvite`
+  - `listReceivedTeamInvites`, `respondTeamInvite`
+  - `listTeamRoles`, `listTeamRoleTemplates`, `listTeamRoleOperations`
+  - `retrieveTeamRole`, `createTeamRole`, `updateTeamRole`, `deleteTeamRole`

--- a/VERSION.md
+++ b/VERSION.md
@@ -7,3 +7,7 @@
   - `listReceivedTeamInvites`, `respondTeamInvite`
   - `listTeamRoles`, `listTeamRoleTemplates`, `listTeamRoleOperations`
   - `retrieveTeamRole`, `createTeamRole`, `updateTeamRole`, `deleteTeamRole`
+
+## Changed
+- `organizations.checkDomainAvailability($query)` is now the canonical method for domain checks.
+- `organizations.checkDomainIsAvailable(...)` remains available as a deprecated alias for v4 compatibility.

--- a/src/Resources/Organizations.php
+++ b/src/Resources/Organizations.php
@@ -136,7 +136,11 @@ class Organizations extends BaseClient
   /**
    * Check domain availability.
    *
-   * @param array $params Domain check parameters.
+   * @param array|string $idOrParams Domain check parameters when called as
+   *        `checkDomainIsAvailable($params)`, or organization id when called
+   *        with the deprecated signature `checkDomainIsAvailable($id, $params)`.
+   * @param array|null $params Domain check parameters for the deprecated
+   *        two-argument signature.
    * @return mixed JSON-decoded response.
    *
    * @throws FacturapiException

--- a/src/Resources/Organizations.php
+++ b/src/Resources/Organizations.php
@@ -452,4 +452,327 @@ class Organizations extends BaseClient
       throw $e;
     }
   }
+
+  /**
+   * List users with access to an organization.
+   *
+   * @param string $organizationId Organization ID.
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
+   */
+  public function listTeamAccess($organizationId): mixed
+  {
+    try {
+      return json_decode($this->executeGetRequest($this->getRequestUrl($organizationId) . "/team"));
+    } catch (FacturapiException $e) {
+      throw $e;
+    }
+  }
+
+  /**
+   * Retrieve one user access entry within an organization.
+   *
+   * @param string $organizationId Organization ID.
+   * @param string $accessId Access ID.
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
+   */
+  public function retrieveTeamAccess($organizationId, $accessId): mixed
+  {
+    try {
+      return json_decode($this->executeGetRequest($this->getRequestUrl($organizationId) . "/team/" . $accessId));
+    } catch (FacturapiException $e) {
+      throw $e;
+    }
+  }
+
+  /**
+   * Reassign a role to a user access entry.
+   *
+   * @param string $organizationId Organization ID.
+   * @param string $accessId Access ID.
+   * @param string $role Role ID.
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
+   */
+  public function updateTeamAccessRole($organizationId, $accessId, $role): mixed
+  {
+    try {
+      return json_decode(
+        $this->executeJsonPutRequest(
+          $this->getRequestUrl($organizationId) . "/team/" . $accessId . "/role",
+          ["role" => $role]
+        )
+      );
+    } catch (FacturapiException $e) {
+      throw $e;
+    }
+  }
+
+  /**
+   * Remove a user access entry from an organization.
+   *
+   * @param string $organizationId Organization ID.
+   * @param string $accessId Access ID.
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
+   */
+  public function removeTeamAccess($organizationId, $accessId): mixed
+  {
+    try {
+      return json_decode(
+        $this->executeDeleteRequest(
+          $this->getRequestUrl($organizationId) . "/team/" . $accessId,
+          null
+        )
+      );
+    } catch (FacturapiException $e) {
+      throw $e;
+    }
+  }
+
+  /**
+   * List sent team invites for an organization.
+   *
+   * @param string $organizationId Organization ID.
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
+   */
+  public function listSentTeamInvites($organizationId): mixed
+  {
+    try {
+      return json_decode($this->executeGetRequest($this->getRequestUrl($organizationId) . "/team/invites"));
+    } catch (FacturapiException $e) {
+      throw $e;
+    }
+  }
+
+  /**
+   * Create or update a team invite for an organization.
+   *
+   * @param string $organizationId Organization ID.
+   * @param array $params Invite payload.
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
+   */
+  public function inviteUserToTeam($organizationId, $params): mixed
+  {
+    try {
+      return json_decode(
+        $this->executeJsonPostRequest(
+          $this->getRequestUrl($organizationId) . "/team/invites",
+          $params
+        )
+      );
+    } catch (FacturapiException $e) {
+      throw $e;
+    }
+  }
+
+  /**
+   * Cancel a pending team invite.
+   *
+   * @param string $organizationId Organization ID.
+   * @param string $inviteKey Invite key.
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
+   */
+  public function cancelTeamInvite($organizationId, $inviteKey): mixed
+  {
+    try {
+      return json_decode(
+        $this->executeDeleteRequest(
+          $this->getRequestUrl($organizationId) . "/team/invites/" . $inviteKey,
+          null
+        )
+      );
+    } catch (FacturapiException $e) {
+      throw $e;
+    }
+  }
+
+  /**
+   * List pending invites received by the authenticated user.
+   *
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
+   */
+  public function listReceivedTeamInvites(): mixed
+  {
+    try {
+      return json_decode($this->executeGetRequest($this->getRequestUrl("invites/pending")));
+    } catch (FacturapiException $e) {
+      throw $e;
+    }
+  }
+
+  /**
+   * Respond to a team invite.
+   *
+   * @param string $inviteKey Invite key.
+   * @param array $params Response payload.
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
+   */
+  public function respondTeamInvite($inviteKey, $params): mixed
+  {
+    try {
+      return json_decode(
+        $this->executeJsonPostRequest(
+          $this->getRequestUrl("invites/" . $inviteKey . "/response"),
+          $params
+        )
+      );
+    } catch (FacturapiException $e) {
+      throw $e;
+    }
+  }
+
+  /**
+   * List organization team roles.
+   *
+   * @param string $organizationId Organization ID.
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
+   */
+  public function listTeamRoles($organizationId): mixed
+  {
+    try {
+      return json_decode($this->executeGetRequest($this->getRequestUrl($organizationId) . "/team/roles"));
+    } catch (FacturapiException $e) {
+      throw $e;
+    }
+  }
+
+  /**
+   * List team role templates.
+   *
+   * @param string $organizationId Organization ID.
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
+   */
+  public function listTeamRoleTemplates($organizationId): mixed
+  {
+    try {
+      return json_decode($this->executeGetRequest($this->getRequestUrl($organizationId) . "/team/roles/templates"));
+    } catch (FacturapiException $e) {
+      throw $e;
+    }
+  }
+
+  /**
+   * List team role operations.
+   *
+   * @param string $organizationId Organization ID.
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
+   */
+  public function listTeamRoleOperations($organizationId): mixed
+  {
+    try {
+      return json_decode($this->executeGetRequest($this->getRequestUrl($organizationId) . "/team/roles/operations"));
+    } catch (FacturapiException $e) {
+      throw $e;
+    }
+  }
+
+  /**
+   * Retrieve a team role by ID.
+   *
+   * @param string $organizationId Organization ID.
+   * @param string $roleId Role ID.
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
+   */
+  public function retrieveTeamRole($organizationId, $roleId): mixed
+  {
+    try {
+      return json_decode($this->executeGetRequest($this->getRequestUrl($organizationId) . "/team/roles/" . $roleId));
+    } catch (FacturapiException $e) {
+      throw $e;
+    }
+  }
+
+  /**
+   * Create a team role.
+   *
+   * @param string $organizationId Organization ID.
+   * @param array $params Role payload.
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
+   */
+  public function createTeamRole($organizationId, $params): mixed
+  {
+    try {
+      return json_decode(
+        $this->executeJsonPostRequest(
+          $this->getRequestUrl($organizationId) . "/team/roles",
+          $params
+        )
+      );
+    } catch (FacturapiException $e) {
+      throw $e;
+    }
+  }
+
+  /**
+   * Update a team role.
+   *
+   * @param string $organizationId Organization ID.
+   * @param string $roleId Role ID.
+   * @param array $params Role payload.
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
+   */
+  public function updateTeamRole($organizationId, $roleId, $params): mixed
+  {
+    try {
+      return json_decode(
+        $this->executeJsonPutRequest(
+          $this->getRequestUrl($organizationId) . "/team/roles/" . $roleId,
+          $params
+        )
+      );
+    } catch (FacturapiException $e) {
+      throw $e;
+    }
+  }
+
+  /**
+   * Delete a team role.
+   *
+   * @param string $organizationId Organization ID.
+   * @param string $roleId Role ID.
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
+   */
+  public function deleteTeamRole($organizationId, $roleId): mixed
+  {
+    try {
+      return json_decode(
+        $this->executeDeleteRequest(
+          $this->getRequestUrl($organizationId) . "/team/roles/" . $roleId,
+          null
+        )
+      );
+    } catch (FacturapiException $e) {
+      throw $e;
+    }
+  }
 }

--- a/src/Resources/Organizations.php
+++ b/src/Resources/Organizations.php
@@ -141,10 +141,10 @@ class Organizations extends BaseClient
    *
    * @throws FacturapiException
    */
-  public function checkDomainIsAvailable($query): mixed
+  public function checkDomainAvailability($query): mixed
   {
     if (!is_array($query)) {
-      throw new FacturapiException('checkDomainIsAvailable expects $query to be an array.');
+      throw new FacturapiException('checkDomainAvailability expects $query to be an array.');
     }
 
     try {
@@ -159,11 +159,32 @@ class Organizations extends BaseClient
   }
 
   /**
-   * Alias for consistency with API operation naming.
+   * @deprecated Use checkDomainAvailability($query) instead. This alias will be removed in v5.
+   *
+   * @param array|string $idOrQuery Domain check query parameters, or legacy organization ID.
+   * @param array|null $query Legacy query parameters when using historical signature.
+   * @return mixed JSON-decoded response.
+   *
+   * @throws FacturapiException
    */
-  public function checkDomainAvailability($query): mixed
+  public function checkDomainIsAvailable($idOrQuery, $query = null): mixed
   {
-    return $this->checkDomainIsAvailable($query);
+    trigger_error(
+      'Organizations::checkDomainIsAvailable(...) is deprecated and will be removed in v5. Use checkDomainAvailability($query) instead.',
+      E_USER_DEPRECATED
+    );
+
+    $argsCount = func_num_args();
+    if ($argsCount === 1 && is_array($idOrQuery)) {
+      return $this->checkDomainAvailability($idOrQuery);
+    }
+
+    if ($argsCount >= 2 && is_array($query)) {
+      // Backward compatibility with historical signature: ($id, $params).
+      return $this->checkDomainAvailability($query);
+    }
+
+    throw new FacturapiException('checkDomainIsAvailable expects either ($query) or ($id, $params).');
   }
 
   /**

--- a/src/Resources/Organizations.php
+++ b/src/Resources/Organizations.php
@@ -136,33 +136,21 @@ class Organizations extends BaseClient
   /**
    * Check domain availability.
    *
-   * @param array|string $idOrParams Domain check parameters when called as
-   *        `checkDomainIsAvailable($params)`, or organization id when called
-   *        with the deprecated signature `checkDomainIsAvailable($id, $params)`.
-   * @param array|null $params Domain check parameters for the deprecated
-   *        two-argument signature.
+   * @param array $params Domain check parameters.
    * @return mixed JSON-decoded response.
    *
    * @throws FacturapiException
    */
-  public function checkDomainIsAvailable($idOrParams, $params = null): mixed
+  public function checkDomainIsAvailable($params): mixed
   {
-    $argsCount = func_num_args();
-    $query = null;
-    if ($argsCount === 1 && is_array($idOrParams)) {
-      $query = $idOrParams;
-    } elseif ($argsCount >= 2 && is_array($params)) {
-      // Backward compatibility with historical signature: ($id, $params).
-      trigger_error('Organizations::checkDomainIsAvailable($id, $params) is deprecated and will be removed in v5. Use checkDomainIsAvailable($params) instead.', E_USER_DEPRECATED);
-      $query = $params;
-    } else {
-      throw new FacturapiException('checkDomainIsAvailable expects either ($params) or ($id, $params).');
+    if (!is_array($params)) {
+      throw new FacturapiException('checkDomainIsAvailable expects $params to be an array.');
     }
 
     try {
       return json_decode(
         $this->executeGetRequest(
-          $this->getRequestUrl("domain-check", $query)
+          $this->getRequestUrl("domain-check", $params)
         )
       );
     } catch (FacturapiException $e) {

--- a/src/Resources/Organizations.php
+++ b/src/Resources/Organizations.php
@@ -136,21 +136,21 @@ class Organizations extends BaseClient
   /**
    * Check domain availability.
    *
-   * @param array $params Domain check parameters.
+   * @param array $query Domain check query parameters.
    * @return mixed JSON-decoded response.
    *
    * @throws FacturapiException
    */
-  public function checkDomainIsAvailable($params): mixed
+  public function checkDomainIsAvailable($query): mixed
   {
-    if (!is_array($params)) {
-      throw new FacturapiException('checkDomainIsAvailable expects $params to be an array.');
+    if (!is_array($query)) {
+      throw new FacturapiException('checkDomainIsAvailable expects $query to be an array.');
     }
 
     try {
       return json_decode(
         $this->executeGetRequest(
-          $this->getRequestUrl("domain-check", $params)
+          $this->getRequestUrl("domain-check", $query)
         )
       );
     } catch (FacturapiException $e) {
@@ -161,9 +161,9 @@ class Organizations extends BaseClient
   /**
    * Alias for consistency with API operation naming.
    */
-  public function checkDomainAvailability($params): mixed
+  public function checkDomainAvailability($query): mixed
   {
-    return $this->checkDomainIsAvailable($params);
+    return $this->checkDomainIsAvailable($query);
   }
 
   /**

--- a/tests/Resources/OrganizationsDomainTest.php
+++ b/tests/Resources/OrganizationsDomainTest.php
@@ -11,12 +11,12 @@ use PHPUnit\Framework\TestCase;
 
 final class OrganizationsDomainTest extends TestCase
 {
-    public function testCheckDomainIsAvailableUsesExpectedEndpoint(): void
+    public function testCheckDomainAvailabilityUsesExpectedEndpoint(): void
     {
         $httpClient = new FakeHttpClient(new Response(200, [], '{"available":true}'));
         $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
 
-        $result = $organizations->checkDomainIsAvailable([
+        $result = $organizations->checkDomainAvailability([
             'name' => 'acme',
             'domain' => 'acme.mx',
         ]);
@@ -31,12 +31,16 @@ final class OrganizationsDomainTest extends TestCase
         );
     }
 
-    public function testCheckDomainAvailabilityAliasDelegatesToCanonicalMethod(): void
+    public function testCheckDomainIsAvailableAliasIsDeprecatedAndDelegatesToCanonicalMethod(): void
     {
         $httpClient = new FakeHttpClient(new Response(200, [], '{"available":true}'));
         $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
 
-        $result = $organizations->checkDomainAvailability([
+        $this->expectUserDeprecationMessage(
+            'Organizations::checkDomainIsAvailable(...) is deprecated and will be removed in v5. Use checkDomainAvailability($query) instead.'
+        );
+
+        $result = $organizations->checkDomainIsAvailable([
             'name' => 'acme',
             'domain' => 'acme.mx',
         ]);
@@ -50,7 +54,7 @@ final class OrganizationsDomainTest extends TestCase
         $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
 
         $this->expectException(\Facturapi\Exceptions\FacturapiException::class);
-        $this->expectExceptionMessage('checkDomainIsAvailable expects $query to be an array.');
+        $this->expectExceptionMessage('checkDomainIsAvailable expects either ($query) or ($id, $params).');
 
         $organizations->checkDomainIsAvailable('invalid');
     }

--- a/tests/Resources/OrganizationsDomainTest.php
+++ b/tests/Resources/OrganizationsDomainTest.php
@@ -31,32 +31,6 @@ final class OrganizationsDomainTest extends TestCase
         );
     }
 
-    public function testCheckDomainIsAvailableAcceptsLegacyTwoArgumentSignature(): void
-    {
-        $httpClient = new FakeHttpClient(new Response(200, [], '{"available":true}'));
-        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
-
-        $captured = [];
-        set_error_handler(static function (int $severity, string $message) use (&$captured): bool {
-            $captured[] = ['severity' => $severity, 'message' => $message];
-            return true;
-        });
-
-        try {
-            $result = $organizations->checkDomainIsAvailable('org_ignored', [
-                'name' => 'acme',
-                'domain' => 'acme.mx',
-            ]);
-        } finally {
-            restore_error_handler();
-        }
-
-        self::assertTrue($result->available);
-        self::assertNotEmpty($captured);
-        self::assertSame(E_USER_DEPRECATED, $captured[0]['severity']);
-        self::assertStringContainsString('checkDomainIsAvailable($params)', $captured[0]['message']);
-    }
-
     public function testCheckDomainAvailabilityAliasDelegatesToCanonicalMethod(): void
     {
         $httpClient = new FakeHttpClient(new Response(200, [], '{"available":true}'));
@@ -68,5 +42,16 @@ final class OrganizationsDomainTest extends TestCase
         ]);
 
         self::assertTrue($result->available);
+    }
+
+    public function testCheckDomainIsAvailableThrowsWhenParamsAreNotArray(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '{"available":true}'));
+        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+
+        $this->expectException(\Facturapi\Exceptions\FacturapiException::class);
+        $this->expectExceptionMessage('checkDomainIsAvailable expects $params to be an array.');
+
+        $organizations->checkDomainIsAvailable('invalid');
     }
 }

--- a/tests/Resources/OrganizationsDomainTest.php
+++ b/tests/Resources/OrganizationsDomainTest.php
@@ -50,7 +50,7 @@ final class OrganizationsDomainTest extends TestCase
         $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
 
         $this->expectException(\Facturapi\Exceptions\FacturapiException::class);
-        $this->expectExceptionMessage('checkDomainIsAvailable expects $params to be an array.');
+        $this->expectExceptionMessage('checkDomainIsAvailable expects $query to be an array.');
 
         $organizations->checkDomainIsAvailable('invalid');
     }

--- a/tests/Resources/OrganizationsMultipartTest.php
+++ b/tests/Resources/OrganizationsMultipartTest.php
@@ -17,24 +17,26 @@ final class OrganizationsMultipartTest extends TestCase
         $tmpLogo = tempnam(sys_get_temp_dir(), 'logo_');
         file_put_contents($tmpLogo, 'LOGO_BYTES');
 
-        $httpClient = new FakeHttpClient(new Response(200, [], '{"ok":true}'));
-        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+        try {
+            $httpClient = new FakeHttpClient(new Response(200, [], '{"ok":true}'));
+            $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
 
-        $result = $organizations->uploadLogo('org_123', $tmpLogo);
+            $result = $organizations->uploadLogo('org_123', $tmpLogo);
 
-        self::assertTrue($result->ok);
+            self::assertTrue($result->ok);
 
-        $request = $httpClient->requests()[0];
-        self::assertSame('PUT', $request->getMethod());
-        self::assertSame('https://www.facturapi.io/v2/organizations/org_123/logo', (string) $request->getUri());
-        self::assertStringStartsWith('multipart/form-data; boundary=', $request->getHeaderLine('Content-Type'));
+            $request = $httpClient->requests()[0];
+            self::assertSame('PUT', $request->getMethod());
+            self::assertSame('https://www.facturapi.io/v2/organizations/org_123/logo', (string) $request->getUri());
+            self::assertStringStartsWith('multipart/form-data; boundary=', $request->getHeaderLine('Content-Type'));
 
-        $body = (string) $request->getBody();
-        self::assertStringContainsString('name="file"', $body);
-        self::assertStringContainsString('filename="' . basename($tmpLogo) . '"', $body);
-        self::assertStringContainsString('LOGO_BYTES', $body);
-
-        @unlink($tmpLogo);
+            $body = (string) $request->getBody();
+            self::assertStringContainsString('name="file"', $body);
+            self::assertStringContainsString('filename="' . basename($tmpLogo) . '"', $body);
+            self::assertStringContainsString('LOGO_BYTES', $body);
+        } finally {
+            @unlink($tmpLogo);
+        }
     }
 
     public function testUploadCertificateBuildsMultipartRequestWithCerKeyAndPassword(): void
@@ -44,31 +46,33 @@ final class OrganizationsMultipartTest extends TestCase
         file_put_contents($tmpCer, 'CER_BYTES');
         file_put_contents($tmpKey, 'KEY_BYTES');
 
-        $httpClient = new FakeHttpClient(new Response(200, [], '{"ok":true}'));
-        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+        try {
+            $httpClient = new FakeHttpClient(new Response(200, [], '{"ok":true}'));
+            $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
 
-        $result = $organizations->uploadCertificate('org_123', [
-            'cerFile' => $tmpCer,
-            'keyFile' => $tmpKey,
-            'password' => 'secret_password',
-        ]);
+            $result = $organizations->uploadCertificate('org_123', [
+                'cerFile' => $tmpCer,
+                'keyFile' => $tmpKey,
+                'password' => 'secret_password',
+            ]);
 
-        self::assertTrue($result->ok);
+            self::assertTrue($result->ok);
 
-        $request = $httpClient->requests()[0];
-        self::assertSame('PUT', $request->getMethod());
-        self::assertSame('https://www.facturapi.io/v2/organizations/org_123/certificate', (string) $request->getUri());
+            $request = $httpClient->requests()[0];
+            self::assertSame('PUT', $request->getMethod());
+            self::assertSame('https://www.facturapi.io/v2/organizations/org_123/certificate', (string) $request->getUri());
 
-        $body = (string) $request->getBody();
-        self::assertStringContainsString('name="cer"', $body);
-        self::assertStringContainsString('name="key"', $body);
-        self::assertStringContainsString('name="password"', $body);
-        self::assertStringContainsString('CER_BYTES', $body);
-        self::assertStringContainsString('KEY_BYTES', $body);
-        self::assertStringContainsString('secret_password', $body);
-
-        @unlink($tmpCer);
-        @unlink($tmpKey);
+            $body = (string) $request->getBody();
+            self::assertStringContainsString('name="cer"', $body);
+            self::assertStringContainsString('name="key"', $body);
+            self::assertStringContainsString('name="password"', $body);
+            self::assertStringContainsString('CER_BYTES', $body);
+            self::assertStringContainsString('KEY_BYTES', $body);
+            self::assertStringContainsString('secret_password', $body);
+        } finally {
+            @unlink($tmpCer);
+            @unlink($tmpKey);
+        }
     }
 
     public function testUploadCertificateFailsWhenRequiredFieldsAreMissing(): void

--- a/tests/Resources/OrganizationsTeamManagementTest.php
+++ b/tests/Resources/OrganizationsTeamManagementTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Facturapi\Tests\Resources;
+
+use Facturapi\Resources\Organizations;
+use Facturapi\Tests\Support\FakeHttpClient;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+final class OrganizationsTeamManagementTest extends TestCase
+{
+    public function testListTeamAccessUsesExpectedEndpoint(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '[]'));
+        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+
+        $result = $organizations->listTeamAccess('org_123');
+
+        self::assertIsArray($result);
+        $request = $httpClient->requests()[0];
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame('https://www.facturapi.io/v2/organizations/org_123/team', (string) $request->getUri());
+    }
+
+    public function testRetrieveTeamAccessUsesExpectedEndpoint(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '{"id":"acc_123"}'));
+        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+
+        $result = $organizations->retrieveTeamAccess('org_123', 'acc_123');
+
+        self::assertSame('acc_123', $result->id);
+        $request = $httpClient->requests()[0];
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame('https://www.facturapi.io/v2/organizations/org_123/team/acc_123', (string) $request->getUri());
+    }
+
+    public function testInviteUserToTeamUsesExpectedEndpointAndJsonBody(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '{"id":"inv_123"}'));
+        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+
+        $result = $organizations->inviteUserToTeam('org_123', [
+            'email' => 'alex@example.com',
+            'role' => 'role_123',
+        ]);
+
+        self::assertSame('inv_123', $result->id);
+        $request = $httpClient->requests()[0];
+        self::assertSame('POST', $request->getMethod());
+        self::assertSame('https://www.facturapi.io/v2/organizations/org_123/team/invites', (string) $request->getUri());
+        self::assertSame('application/json', $request->getHeaderLine('Content-Type'));
+        self::assertStringContainsString('"email":"alex@example.com"', (string) $request->getBody());
+        self::assertStringContainsString('"role":"role_123"', (string) $request->getBody());
+    }
+
+    public function testListSentTeamInvitesUsesExpectedEndpoint(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '[]'));
+        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+
+        $result = $organizations->listSentTeamInvites('org_123');
+
+        self::assertIsArray($result);
+        $request = $httpClient->requests()[0];
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame('https://www.facturapi.io/v2/organizations/org_123/team/invites', (string) $request->getUri());
+    }
+
+    public function testCancelTeamInviteUsesExpectedEndpoint(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '{"ok":true}'));
+        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+
+        $result = $organizations->cancelTeamInvite('org_123', 'inv_123');
+
+        self::assertTrue($result->ok);
+        $request = $httpClient->requests()[0];
+        self::assertSame('DELETE', $request->getMethod());
+        self::assertSame('https://www.facturapi.io/v2/organizations/org_123/team/invites/inv_123', (string) $request->getUri());
+    }
+
+    public function testListReceivedTeamInvitesUsesExpectedEndpoint(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '[]'));
+        $organizations = new Organizations('sk_user_abc123', ['httpClient' => $httpClient]);
+
+        $result = $organizations->listReceivedTeamInvites();
+
+        self::assertIsArray($result);
+        $request = $httpClient->requests()[0];
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame('https://www.facturapi.io/v2/organizations/invites/pending', (string) $request->getUri());
+    }
+
+    public function testRespondTeamInviteUsesExpectedEndpointAndJsonBody(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '{"ok":true}'));
+        $organizations = new Organizations('sk_user_abc123', ['httpClient' => $httpClient]);
+
+        $result = $organizations->respondTeamInvite('inv_123', ['accept' => true]);
+
+        self::assertTrue($result->ok);
+        $request = $httpClient->requests()[0];
+        self::assertSame('POST', $request->getMethod());
+        self::assertSame('https://www.facturapi.io/v2/organizations/invites/inv_123/response', (string) $request->getUri());
+        self::assertSame('application/json', $request->getHeaderLine('Content-Type'));
+        self::assertStringContainsString('"accept":true', (string) $request->getBody());
+    }
+
+    public function testListTeamRolesUsesExpectedEndpoint(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '[]'));
+        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+
+        $result = $organizations->listTeamRoles('org_123');
+
+        self::assertIsArray($result);
+        $request = $httpClient->requests()[0];
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame('https://www.facturapi.io/v2/organizations/org_123/team/roles', (string) $request->getUri());
+    }
+
+    public function testListTeamRoleTemplatesUsesExpectedEndpoint(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '[]'));
+        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+
+        $result = $organizations->listTeamRoleTemplates('org_123');
+
+        self::assertIsArray($result);
+        $request = $httpClient->requests()[0];
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame('https://www.facturapi.io/v2/organizations/org_123/team/roles/templates', (string) $request->getUri());
+    }
+
+    public function testListTeamRoleOperationsUsesExpectedEndpoint(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '[]'));
+        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+
+        $result = $organizations->listTeamRoleOperations('org_123');
+
+        self::assertIsArray($result);
+        $request = $httpClient->requests()[0];
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame('https://www.facturapi.io/v2/organizations/org_123/team/roles/operations', (string) $request->getUri());
+    }
+
+    public function testRetrieveTeamRoleUsesExpectedEndpoint(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '{"id":"role_123"}'));
+        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+
+        $result = $organizations->retrieveTeamRole('org_123', 'role_123');
+
+        self::assertSame('role_123', $result->id);
+        $request = $httpClient->requests()[0];
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame('https://www.facturapi.io/v2/organizations/org_123/team/roles/role_123', (string) $request->getUri());
+    }
+
+    public function testCreateTeamRoleUsesExpectedEndpointAndJsonBody(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '{"id":"role_123","name":"Billing analyst"}'));
+        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+
+        $result = $organizations->createTeamRole('org_123', [
+            'name' => 'Billing analyst',
+            'operations' => ['read:invoices'],
+        ]);
+
+        self::assertSame('role_123', $result->id);
+        $request = $httpClient->requests()[0];
+        self::assertSame('POST', $request->getMethod());
+        self::assertSame('https://www.facturapi.io/v2/organizations/org_123/team/roles', (string) $request->getUri());
+        self::assertSame('application/json', $request->getHeaderLine('Content-Type'));
+        self::assertStringContainsString('"name":"Billing analyst"', (string) $request->getBody());
+        self::assertStringContainsString('"operations":["read:invoices"]', (string) $request->getBody());
+    }
+
+    public function testUpdateTeamAccessRoleUsesExpectedEndpointAndJsonBody(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '{"id":"acc_123","role":"role_123"}'));
+        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+
+        $result = $organizations->updateTeamAccessRole('org_123', 'acc_123', 'role_123');
+
+        self::assertSame('acc_123', $result->id);
+        self::assertSame('role_123', $result->role);
+        $request = $httpClient->requests()[0];
+        self::assertSame('PUT', $request->getMethod());
+        self::assertSame('https://www.facturapi.io/v2/organizations/org_123/team/acc_123/role', (string) $request->getUri());
+        self::assertSame('application/json', $request->getHeaderLine('Content-Type'));
+        self::assertStringContainsString('"role":"role_123"', (string) $request->getBody());
+    }
+
+    public function testRemoveTeamAccessUsesExpectedEndpoint(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '{"ok":true}'));
+        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+
+        $result = $organizations->removeTeamAccess('org_123', 'acc_123');
+
+        self::assertTrue($result->ok);
+        $request = $httpClient->requests()[0];
+        self::assertSame('DELETE', $request->getMethod());
+        self::assertSame('https://www.facturapi.io/v2/organizations/org_123/team/acc_123', (string) $request->getUri());
+    }
+
+    public function testUpdateTeamRoleUsesExpectedEndpointAndJsonBody(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '{"id":"role_123","name":"Senior billing analyst"}'));
+        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+
+        $result = $organizations->updateTeamRole('org_123', 'role_123', [
+            'name' => 'Senior billing analyst',
+        ]);
+
+        self::assertSame('role_123', $result->id);
+        self::assertSame('Senior billing analyst', $result->name);
+        $request = $httpClient->requests()[0];
+        self::assertSame('PUT', $request->getMethod());
+        self::assertSame('https://www.facturapi.io/v2/organizations/org_123/team/roles/role_123', (string) $request->getUri());
+        self::assertSame('application/json', $request->getHeaderLine('Content-Type'));
+        self::assertStringContainsString('"name":"Senior billing analyst"', (string) $request->getBody());
+    }
+
+    public function testDeleteTeamRoleUsesExpectedEndpoint(): void
+    {
+        $httpClient = new FakeHttpClient(new Response(200, [], '{"ok":true}'));
+        $organizations = new Organizations('sk_test_abc123', ['httpClient' => $httpClient]);
+
+        $result = $organizations->deleteTeamRole('org_123', 'role_123');
+
+        self::assertTrue($result->ok);
+        $request = $httpClient->requests()[0];
+        self::assertSame('DELETE', $request->getMethod());
+        self::assertSame('https://www.facturapi.io/v2/organizations/org_123/team/roles/role_123', (string) $request->getUri());
+    }
+}


### PR DESCRIPTION
## Summary
- add organization team management methods to the PHP SDK (access, invites, and team roles)
- modernize SDK v4 internals and runtime behavior:
  - PSR-18 HTTP layer (Guzzle-backed default)
  - richer `FacturapiException` with status/error payload/raw body
  - consistent non-2xx handling across request methods
- keep compatibility and migration clarity:
  - snake_case and legacy aliases deprecations where applicable
  - Composer and non-Composer loading paths documented
- update docs and release automation:
  - `VERSION.md` semver + release notes flow
  - deploy workflow aligned to `VERSION.md`
- add/expand PHPUnit coverage across critical paths and edge cases
- add CI workflow for `pull_request`, `push` to `main`, and `workflow_dispatch`

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml`
