### PR TITLE
fix: devolver códigos de error como strings

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -1,3 +1,8 @@
+4.7.1
+
+## Fixed
+- Return numeric API error codes as strings.
+
 4.7.0
 
 ## Added

--- a/src/Exceptions/FacturapiException.php
+++ b/src/Exceptions/FacturapiException.php
@@ -48,9 +48,23 @@ class FacturapiException extends Exception
 		return $this->rawBody;
 	}
 
-	public function getErrorCode(): mixed
+	public function getErrorCode(): ?string
 	{
-		return is_array($this->errorData) ? ($this->errorData['code'] ?? null) : null;
+		if (!is_array($this->errorData) || !array_key_exists('code', $this->errorData)) {
+			return null;
+		}
+
+		$code = $this->errorData['code'];
+		if ($code === null) {
+			return null;
+		}
+
+		if (is_string($code)) {
+			return $code;
+		}
+
+		$encoded = json_encode($code);
+		return $encoded === false ? null : $encoded;
 	}
 
 	public function getErrorPath(): ?string

--- a/src/Exceptions/FacturapiException.php
+++ b/src/Exceptions/FacturapiException.php
@@ -63,8 +63,7 @@ class FacturapiException extends Exception
 			return $code;
 		}
 
-		$encoded = json_encode($code);
-		return $encoded === false ? null : $encoded;
+		return is_int($code) || is_float($code) ? (string) $code : null;
 	}
 
 	public function getErrorPath(): ?string

--- a/tests/Http/ErrorHandlingTest.php
+++ b/tests/Http/ErrorHandlingTest.php
@@ -89,4 +89,20 @@ final class ErrorHandlingTest extends TestCase
             self::assertSame($rawBody, $exception->getRawBody());
         }
     }
+
+    public function testNumericApiErrorCodesAreConvertedToStrings(): void
+    {
+        $httpClient = new FakeHttpClient(
+            new Response(400, ['Content-Type' => 'application/json'], '{"code": 400}')
+        );
+
+        $invoices = new Invoices('sk_test_abc123', ['httpClient' => $httpClient]);
+
+        try {
+            $invoices->create(['customer' => []]);
+            self::fail('Expected FacturapiException to be thrown.');
+        } catch (FacturapiException $exception) {
+            self::assertSame('400', $exception->getErrorCode());
+        }
+    }
 }


### PR DESCRIPTION
## Objetivo

Corregir `getErrorCode()` para devolver texto cuando la respuesta de API contiene un código string o numérico.

## Cambios

- Convierte únicamente códigos numéricos legacy a texto.
- Conserva códigos string y omite valores raíz no escalares.
- Agrega cobertura para códigos numéricos.
- Actualiza la versión patch a `4.7.1`.

## Verificación

- `vendor/bin/phpunit`